### PR TITLE
Add utf8 encoding to fs.createReadStream.

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -5,7 +5,7 @@ envify = require 'envify'
 custom = require 'envify/custom'
 
 module.exports = (input, output, vars) ->
-  infile = fs.createReadStream input
+  infile = fs.createReadStream input, { encoding: 'utf8' }
   outfile = fs.createWriteStream output
 
   convert = if vars


### PR DESCRIPTION
Envify uses utf8 by default and so should this.
https://github.com/hughsk/envify/blob/master/bin/envify
